### PR TITLE
Use global fetch and dotenv config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=tu_clave_openai

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ Lint JavaScript files:
 npm run lint
 ```
 
+### Variables de entorno
+
+1. Copia el archivo `.env.example` a `.env`:
+
+```bash
+cp .env.example .env
+```
+
+2. Edita `.env` y asigna tu clave de OpenAI:
+
+```bash
+OPENAI_API_KEY=tu_clave_openai
+```
+
+El servidor leerá esta clave al iniciarse para comunicarse con la API de OpenAI.
+
 ### Naming Conventions
 
 All directories and files use **kebab-case** (lowercase words separated by hyphens).

--- a/ai_server.js
+++ b/ai_server.js
@@ -9,9 +9,9 @@
  * task. The server constructs an appropriate system message, forwards
  * the request to OpenAI, and returns the assistant's reply as JSON.
  */
+require('dotenv').config();
 
 const express = require('express');
-const fetch = require('node-fetch');
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -23,7 +23,7 @@ app.use(express.json());
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 if (!OPENAI_API_KEY) {
   console.warn(
-    'Warning: The OPENAI_API_KEY environment variable is not set. The server will reject requests.',
+    'Advertencia: la variable de entorno OPENAI_API_KEY no está configurada. El servidor rechazará las solicitudes.',
   );
 }
 
@@ -36,7 +36,7 @@ function buildSystemMessage(task) {
     case 'summarize':
       return 'Eres un asistente que resume textos en español de forma concisa.';
     case 'translate':
-      return 'You are a translator that translates Spanish text to English.';
+      return 'Eres un traductor que convierte textos del español al inglés.';
     case 'question':
       return 'Eres un experto que responde preguntas educativas en español.';
     case 'example':
@@ -81,7 +81,9 @@ app.post('/api/chat', async (req, res) => {
     });
     if (!response.ok) {
       const errorText = await response.text();
-      return res.status(response.status).send(errorText);
+      return res
+        .status(response.status)
+        .send(`Error del servicio de OpenAI: ${errorText}`);
     }
     const data = await response.json();
     const result = data.choices?.[0]?.message?.content?.trim() || '';
@@ -99,5 +101,5 @@ app.use(express.static('.'));
 
 // Start the server
 app.listen(port, () => {
-  console.log(`AI proxy server listening on http://localhost:${port}`);
+  console.log(`Servidor proxy de IA escuchando en http://localhost:${port}`);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "powersemiotics",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
       "devDependencies": {
         "eslint": "^8.57.1",
         "prettier": "^3.6.2"
@@ -355,6 +358,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/escape-string-regexp": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "author": "",
   "license": "ISC",
   "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^16.4.5"
+  },
   "devDependencies": {
     "eslint": "^8.57.1",
     "prettier": "^3.6.2"


### PR DESCRIPTION
## Summary
- use Node's built-in fetch instead of node-fetch
- load OpenAI API key from a `.env` file and add sample config
- standardize server warnings and errors in Spanish

## Testing
- `npm test` (fails: `Error: no test specified`)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897f47f5eb0832e84fd9aa7349b3bd9