### PR TITLE
Remove Tópicos navigation button

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,11 +27,6 @@
         </a>
         <div>
           <a
-            href="topics.html"
-            class="text-indigo-600 font-semibold hover:underline mr-4"
-            >Tópicos</a
-          >
-          <a
             href="ai_dashboard.html"
             class="text-indigo-600 font-semibold hover:underline mr-4"
             >AI Dashboard (API)</a


### PR DESCRIPTION
## Summary
- remove the "Tópicos" link from the homepage navigation bar

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a315e11a8832eac94d4c078aff093