### PR TITLE
Align gastroenterology hub module links

### DIFF
--- a/gastroenterologia.html
+++ b/gastroenterologia.html
@@ -46,7 +46,7 @@
       <div
         class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"
       >
-        <!-- NUEVA TARJETA: Hemorragia Digestiva -->
+        <!-- Módulo: Hemorragia Digestiva -->
         <a
           href="gastroenterologia/hemorragia-GI.html"
           class="block w-full bg-white p-8 rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-200 group card-hover-effect"
@@ -63,132 +63,67 @@
           </p>
         </a>
 
-        <!-- Tarjetas existentes -->
+        <!-- Módulo: Colitis Ulcerosa -->
         <a
-          href="neurologia/neuropatias.html"
+          href="gastroenterologia/colitis-ulcerosa.html"
           class="block w-full bg-white p-8 rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-200 group card-hover-effect"
         >
           <div class="flex items-center mb-4">
-            <i
-              class="fas fa-network-wired text-4xl gradient-text"
-              style="background: -webkit-linear-gradient(#4338ca, #be185d)"
-            ></i>
+            <i class="fas fa-notes-medical text-4xl gradient-text"></i>
           </div>
           <h2 class="text-2xl font-bold text-gray-800">
-            Módulo: Neuropatías Periféricas
+            Módulo: Colitis Ulcerosa
           </h2>
           <p class="text-gray-600 text-md mt-2">
-            Enfoque integral desde la fisiopatología hasta la práctica clínica
-            en el contexto ecuatoriano.
-          </p>
-        </a>
-        <a
-          href="neurologia/cefaleas/index.html"
-          class="block w-full bg-white p-8 rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-200 group card-hover-effect"
-        >
-          <div class="flex items-center mb-4">
-            <i
-              class="fas fa-head-side-virus text-4xl gradient-text"
-              style="background: -webkit-linear-gradient(#4338ca, #be185d)"
-            ></i>
-          </div>
-          <h2 class="text-2xl font-bold text-gray-800">Módulo: Cefaleas</h2>
-          <p class="text-gray-600 text-md mt-2">
-            Un curso interactivo para el abordaje diagnóstico y manejo de las
-            cefaleas primarias más importantes.
+            Diagnóstico y manejo de la colitis ulcerosa adaptado al contexto ecuatoriano.
           </p>
         </a>
 
+        <!-- Módulo: Enfermedad Hepática I -->
         <a
-          href="neurologia/epilepsia-ii/index.html"
+          href="gastroenterologia/enfermedad_hepatica_i/index.html"
           class="block w-full bg-white p-8 rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-200 group card-hover-effect"
         >
           <div class="flex items-center mb-4">
-            <i
-              class="fas fa-bolt text-4xl gradient-text"
-              style="background: -webkit-linear-gradient(#4338ca, #be185d)"
-            ></i>
+            <i class="fas fa-liver text-4xl gradient-text"></i>
           </div>
-          <h2 class="text-2xl font-bold text-gray-800">Módulo: Epilepsia II</h2>
+          <h2 class="text-2xl font-bold text-gray-800">
+            Módulo: Enfermedad Hepática I
+          </h2>
           <p class="text-gray-600 text-md mt-2">
-            Análisis avanzado sobre el tratamiento, la farmacoresistencia y las
-            nuevas terapias en epilepsia.
+            Pruebas de función hepática y patrones de lesión en la evaluación inicial.
           </p>
         </a>
 
+        <!-- Módulo: Enfermedad Hepática II -->
         <a
-          href="neurologia/trastornos-movimiento-1.html"
+          href="gastroenterologia/enfermedad_hepatica_ii/index.html"
           class="block w-full bg-white p-8 rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-200 group card-hover-effect"
         >
           <div class="flex items-center mb-4">
-            <i
-              class="fas fa-walking text-4xl gradient-text"
-              style="background: -webkit-linear-gradient(#4338ca, #be185d)"
-            ></i>
+            <i class="fas fa-vials text-4xl gradient-text"></i>
           </div>
           <h2 class="text-2xl font-bold text-gray-800">
-            Módulo: Trastornos del Movimiento I
+            Módulo: Enfermedad Hepática II
           </h2>
           <p class="text-gray-600 text-md mt-2">
-            Fundamentos de la Enfermedad de Parkinson, desde la fisiopatología
-            hasta el diagnóstico clínico.
+            Complicaciones y manejo avanzado de la enfermedad hepática.
           </p>
         </a>
 
+        <!-- Módulo: Pancreatitis Aguda -->
         <a
-          href="neurologia/trastornos-movimiento-2.html"
+          href="gastroenterologia/pancreatitis_aguda/index.html"
           class="block w-full bg-white p-8 rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-200 group card-hover-effect"
         >
           <div class="flex items-center mb-4">
-            <i
-              class="fas fa-sitemap text-4xl gradient-text"
-              style="background: -webkit-linear-gradient(#4338ca, #be185d)"
-            ></i>
+            <i class="fas fa-fire text-4xl gradient-text"></i>
           </div>
           <h2 class="text-2xl font-bold text-gray-800">
-            Módulo: Trastornos del Movimiento II
+            Módulo: Pancreatitis Aguda
           </h2>
           <p class="text-gray-600 text-md mt-2">
-            Diagnóstico diferencial de los parkinsonismos atípicos y otras
-            hipercinesias en atención primaria.
-          </p>
-        </a>
-
-        <a
-          href="neurologia/enfermedades_desmielinizantes.html"
-          class="block w-full bg-white p-8 rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-200 group card-hover-effect"
-        >
-          <div class="flex items-center mb-4">
-            <i
-              class="fas fa-brain text-4xl gradient-text"
-              style="background: -webkit-linear-gradient(#4338ca, #be185d)"
-            ></i>
-          </div>
-          <h2 class="text-2xl font-bold text-gray-800">
-            Módulo: Enfermedades Desmielinizantes
-          </h2>
-          <p class="text-gray-600 text-md mt-2">
-            Diagnóstico diferencial de la Esclerosis Múltiple, Neuromielitis
-            Óptica (TENMO) y MOGAD.
-          </p>
-        </a>
-
-        <a
-          href="neurologia/neuromusculares.html"
-          class="block w-full bg-white p-8 rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-200 group card-hover-effect"
-        >
-          <div class="flex items-center mb-4">
-            <i
-              class="fas fa-notes-medical text-4xl gradient-text"
-              style="background: -webkit-linear-gradient(#4338ca, #be185d)"
-            ></i>
-          </div>
-          <h2 class="text-2xl font-bold text-gray-800">
-            Módulo: Enfermedades Neuromusculares
-          </h2>
-          <p class="text-gray-600 text-md mt-2">
-            Análisis de MG, DMD/DMB y MII, con simuladores y actividades para
-            estudiantes de medicina.
+            Patologías del páncreas y vías biliares con actividades interactivas.
           </p>
         </a>
       </div>


### PR DESCRIPTION
## Summary
- Replace neurology module cards with gastroenterology modules on the gastroenterology hub page.
- Link cards to Colitis Ulcerosa, Enfermedad Hepática I & II, and Pancreatitis Aguda resources.

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a33661da8832ebdf2a4e11b6d3537