### PR TITLE
feat: add accessible tab panels for GI bleeding module

### DIFF
--- a/gastroenterologia/hemorragia-GI.html
+++ b/gastroenterologia/hemorragia-GI.html
@@ -29,19 +29,45 @@
             <h3 class="text-lg font-bold text-gray-800 mb-4 px-4">
               Índice del Módulo
             </h3>
-            <nav id="module-nav" class="space-y-1">
-              <a href="#presentacion" class="nav-link active"
-                ><i class="fas fa-desktop nav-icon"></i>Presentación
-                Interactiva</a
+            <nav
+              id="module-nav"
+              class="space-y-1"
+              role="tablist"
+              aria-orientation="vertical"
+              aria-label="Secciones del módulo"
+            >
+              <button
+                id="tab-presentacion"
+                data-target="presentacion"
+                class="nav-link active w-full text-left"
+                role="tab"
+                aria-selected="true"
+                aria-controls="presentacion"
               >
-              <a href="#herramienta" class="nav-link"
-                ><i class="fas fa-stethoscope nav-icon"></i>Herramienta
-                Diagnóstica</a
+                <i class="fas fa-desktop nav-icon"></i>Presentación Interactiva
+              </button>
+              <button
+                id="tab-herramienta"
+                data-target="herramienta"
+                class="nav-link w-full text-left"
+                role="tab"
+                aria-selected="false"
+                aria-controls="herramienta"
               >
-              <a href="#autoevaluacion" class="nav-link"
-                ><i class="fas fa-vial-circle-check nav-icon"></i>Autoevaluación
-                Gamificada</a
+                <i class="fas fa-stethoscope nav-icon"></i>Herramienta
+                Diagnóstica
+              </button>
+              <button
+                id="tab-autoevaluacion"
+                data-target="autoevaluacion"
+                class="nav-link w-full text-left"
+                role="tab"
+                aria-selected="false"
+                aria-controls="autoevaluacion"
               >
+                <i class="fas fa-vial-circle-check nav-icon"></i>Autoevaluación
+                Gamificada
+              </button>
             </nav>
           </div>
         </aside>
@@ -310,11 +336,14 @@
           autoevaluacion: setupQuiz,
         };
 
-        function switchSection(hash) {
-          hash = hash.replace('#', '');
+        function switchSection(target) {
+          const hash = target.replace('#', '');
 
           navLinks.forEach((link) => {
-            link.classList.toggle('active', link.hash === `#${hash}`);
+            const isActive = link.dataset.target === hash;
+            link.classList.toggle('active', isActive);
+            link.setAttribute('aria-selected', isActive);
+            link.setAttribute('tabindex', isActive ? '0' : '-1');
           });
 
           mainContent.innerHTML = '';
@@ -328,6 +357,10 @@
           if (template) {
             const content = template.content.cloneNode(true);
             mainContent.appendChild(content);
+            mainContent.setAttribute('role', 'tabpanel');
+            mainContent.setAttribute('tabindex', '0');
+            mainContent.setAttribute('aria-labelledby', `tab-${hash}`);
+            mainContent.focus();
             if (contentLoaders[hash]) {
               contentLoaders[hash]();
             }
@@ -337,14 +370,24 @@
         navLinks.forEach((link) => {
           link.addEventListener('click', (e) => {
             e.preventDefault();
-            const targetHash = link.getAttribute('href');
-            switchSection(targetHash);
-            history.pushState(null, null, targetHash);
+            const target = link.dataset.target;
+            switchSection(target);
+            history.pushState(null, null, `#${target}`);
+          });
+          link.addEventListener('keydown', (e) => {
+            if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+              e.preventDefault();
+              const index = Array.from(navLinks).indexOf(link);
+              const direction = e.key === 'ArrowDown' ? 1 : -1;
+              const newIndex =
+                (index + direction + navLinks.length) % navLinks.length;
+              navLinks[newIndex].focus();
+            }
           });
         });
 
         // Initial load
-        const initialHash = window.location.hash || '#presentacion';
+        const initialHash = window.location.hash.substring(1) || 'presentacion';
         switchSection(initialHash);
 
         // --- LÓGICA DEL COMPONENTE 1: PRESENTACIÓN ---


### PR DESCRIPTION
## Summary
- convert GI hemorrhage module navigation into an ARIA tablist with button-based tabs
- manage tab panels with focus and keyboard support for better accessibility

## Testing
- `npx prettier gastroenterologia/hemorragia-GI.html -w`
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689d53484e9c832e9ffd78fa1e8805df