### PR TITLE
Embed AI dashboard into diagnostics page

### DIFF
--- a/gastroenterologia/pruebas-diagnosticas.html
+++ b/gastroenterologia/pruebas-diagnosticas.html
@@ -51,13 +51,30 @@
       main#content-area {
         flex-grow: 1;
         padding: 30px;
-        overflow-y: auto;
+        overflow: auto;
         display: flex;
         justify-content: center;
         align-items: center;
       }
 
       #content-wrapper {
+        width: 816px;
+        height: 1056px;
+        background-color: var(--card-bg);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        overflow: auto;
+      }
+
+      aside#ai-panel {
+        width: 360px;
+        background-color: var(--card-bg);
+        box-shadow: -2px 0 10px rgba(0, 0, 0, 0.05);
+        display: flex;
+        flex-direction: column;
+        flex-shrink: 0;
+      }
+      #ai-panel iframe {
+        border: none;
         width: 100%;
         height: 100%;
       }
@@ -365,6 +382,9 @@
           overflow-x: auto;
           padding: 10px;
         }
+        aside#ai-panel {
+          display: none;
+        }
         #side-nav h1 {
           display: none;
         }
@@ -382,6 +402,10 @@
         }
         main#content-area {
           padding: 15px;
+        }
+        #content-wrapper {
+          width: 100%;
+          height: auto;
         }
       }
     </style>
@@ -421,6 +445,13 @@
       <main id="content-area">
         <div id="content-wrapper"></div>
       </main>
+      <aside id="ai-panel">
+        <iframe
+          src="../ai_dashboard.html"
+          title="AI Dashboard"
+          loading="lazy"
+        ></iframe>
+      </aside>
     </div>
 
     <!-- ########## TEMPLATES ########## -->


### PR DESCRIPTION
## Summary
- create letter-sized central canvas and embed AI dashboard in a new right-hand panel
- hide AI panel on small screens for responsive layout

## Testing
- `npx prettier --write gastroenterologia/pruebas-diagnosticas.html`
- `npm run lint`
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a28197eed8832ea7fcacd20b99395b