### PR TITLE
Add shared layout for gastroenterology modules

### DIFF
--- a/assets/gastro-layout.css
+++ b/assets/gastro-layout.css
@@ -1,0 +1,75 @@
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #f0f4f8;
+  color: #333;
+  margin: 0;
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
+}
+#app-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+aside#side-nav {
+  width: 280px;
+  background-color: #ffffff;
+  padding: 25px;
+  box-shadow: 2px 0 10px rgba(0, 0, 0, 0.05);
+  overflow-y: auto;
+  flex-shrink: 0;
+}
+#side-nav h1 {
+  color: #005a9c;
+  font-size: 1.4em;
+  margin: 0 0 30px 0;
+  border-bottom: 2px solid #e3f2fd;
+  padding-bottom: 15px;
+}
+#side-nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+#side-nav li a {
+  display: block;
+  padding: 10px 15px;
+  color: #003366;
+  text-decoration: none;
+  border-radius: 8px;
+  margin-bottom: 10px;
+  font-weight: 500;
+  transition: background-color 0.3s;
+}
+#side-nav li a:hover {
+  background-color: #e3f2fd;
+}
+main#content-area {
+  flex-grow: 1;
+  padding: 30px;
+  overflow: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+#content-wrapper {
+  width: 816px;
+  height: 1056px;
+  max-width: 100%;
+  max-height: 100%;
+  background-color: #ffffff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  overflow: auto;
+}
+aside#ai-panel {
+  width: 360px;
+  background-color: #ffffff;
+  box-shadow: -2px 0 10px rgba(0, 0, 0, 0.05);
+  flex-shrink: 0;
+}
+#ai-panel iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}

--- a/assets/gastro-layout.js
+++ b/assets/gastro-layout.js
@@ -1,0 +1,46 @@
+window.addEventListener('load', () => {
+  if (document.getElementById('app-container')) return;
+
+  const body = document.body;
+  const originalChildren = Array.from(body.childNodes);
+  body.innerHTML = '';
+
+  const app = document.createElement('div');
+  app.id = 'app-container';
+
+  const sideNav = document.createElement('aside');
+  sideNav.id = 'side-nav';
+  const navTitle = document.createElement('h1');
+  navTitle.textContent = 'Contenido';
+  const navList = document.createElement('ul');
+  sideNav.append(navTitle, navList);
+
+  const contentArea = document.createElement('main');
+  contentArea.id = 'content-area';
+  const wrapper = document.createElement('div');
+  wrapper.id = 'content-wrapper';
+  originalChildren.forEach((child) => wrapper.appendChild(child));
+  contentArea.appendChild(wrapper);
+
+  const aiPanel = document.createElement('aside');
+  aiPanel.id = 'ai-panel';
+  const iframe = document.createElement('iframe');
+  iframe.src = '/ai_dashboard.html';
+  aiPanel.appendChild(iframe);
+
+  app.append(sideNav, contentArea, aiPanel);
+  body.appendChild(app);
+
+  const headings = wrapper.querySelectorAll('h2');
+  headings.forEach((h) => {
+    if (!h.id) {
+      h.id = h.textContent.trim().toLowerCase().replace(/[^a-z0-9]+/gi, '-');
+    }
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = `#${h.id}`;
+    a.textContent = h.textContent;
+    li.appendChild(a);
+    navList.appendChild(li);
+  });
+});

--- a/gastroenterologia/colitis-ulcerosa.html
+++ b/gastroenterologia/colitis-ulcerosa.html
@@ -9,6 +9,8 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
     />
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <link rel="stylesheet" href="../assets/gastro-layout.css" />
+    <script src="../assets/gastro-layout.js" defer></script>
     <style>
       /* --- Estilos Generales --- */
       body {

--- a/gastroenterologia/enfermedad_hepatica_i/actividad_abp.html
+++ b/gastroenterologia/enfermedad_hepatica_i/actividad_abp.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Actividad ABP: El Paciente con Transaminasas Elevadas</title>
     <link href="../../assets/tailwind.css" rel="stylesheet" />
+    <link rel="stylesheet" href="../../assets/gastro-layout.css" />
+    <script src="../../assets/gastro-layout.js" defer></script>
   </head>
   <body class="font-sans">
     <div class="max-w-4xl mx-auto p-4 md:p-8">

--- a/gastroenterologia/enfermedad_hepatica_i/autoevaluacion.html
+++ b/gastroenterologia/enfermedad_hepatica_i/autoevaluacion.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Autoevaluación: Enfermedad Hepática I</title>
     <link href="../../assets/tailwind.css" rel="stylesheet" />
+    <link rel="stylesheet" href="../../assets/gastro-layout.css" />
+    <script src="../../assets/gastro-layout.js" defer></script>
   </head>
   <body
     class="font-sans bg-gray-100 flex items-center justify-center min-h-screen"

--- a/gastroenterologia/enfermedad_hepatica_i/index.html
+++ b/gastroenterologia/enfermedad_hepatica_i/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Módulo: Enfermedad Hepática I</title>
     <link href="../../assets/tailwind.css" rel="stylesheet" />
+    <link rel="stylesheet" href="../../assets/gastro-layout.css" />
+    <script src="../../assets/gastro-layout.js" defer></script>
   </head>
   <body class="font-sans bg-gray-900 text-gray-300">
     <div class="container mx-auto p-4 sm:p-6 md:p-8">

--- a/gastroenterologia/enfermedad_hepatica_i/pagina_conocimiento.html
+++ b/gastroenterologia/enfermedad_hepatica_i/pagina_conocimiento.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Banco de Conocimientos: Enfermedad Hepática I</title>
     <link href="../../assets/tailwind.css" rel="stylesheet" />
+    <link rel="stylesheet" href="../../assets/gastro-layout.css" />
+    <script src="../../assets/gastro-layout.js" defer></script>
   </head>
   <body class="font-sans p-4 md:p-8">
     <div class="max-w-4xl mx-auto bg-white rounded-2xl shadow-lg">

--- a/gastroenterologia/enfermedad_hepatica_i/presentacion.html
+++ b/gastroenterologia/enfermedad_hepatica_i/presentacion.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Presentación: Enfermedad Hepática I</title>
     <link href="../../assets/tailwind.css" rel="stylesheet" />
+    <link rel="stylesheet" href="../../assets/gastro-layout.css" />
+    <script src="../../assets/gastro-layout.js" defer></script>
   </head>
   <body class="font-sans bg-gray-100 text-gray-800">
     <div class="relative w-full h-screen flex flex-col">

--- a/gastroenterologia/enfermedad_hepatica_ii/index.html
+++ b/gastroenterologia/enfermedad_hepatica_ii/index.html
@@ -6,6 +6,8 @@
     <title>Guía de Estudio: Enfermedad Hepática</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="../../assets/tailwind.css" rel="stylesheet" />
+    <link rel="stylesheet" href="../../assets/gastro-layout.css" />
+    <script src="../../assets/gastro-layout.js" defer></script>
   </head>
   <body class="font-sans bg-gray-100">
     <div class="flex flex-col md:flex-row min-h-screen">

--- a/gastroenterologia/gastroenteropatias-aines.html
+++ b/gastroenterologia/gastroenteropatias-aines.html
@@ -52,16 +52,32 @@
       main#content-area {
         flex-grow: 1;
         padding: 30px;
-        overflow-y: auto;
+        overflow: auto;
         display: flex;
         justify-content: center;
-        align-items: flex-start;
+        align-items: center;
       }
 
       #content-wrapper {
+        width: 816px;
+        height: 1056px;
+        max-width: 100%;
+        max-height: 100%;
+        background-color: var(--card-bg);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        overflow: auto;
+      }
+
+      aside#ai-panel {
+        width: 360px;
+        background-color: var(--card-bg);
+        box-shadow: -2px 0 10px rgba(0, 0, 0, 0.05);
+        flex-shrink: 0;
+      }
+      #ai-panel iframe {
         width: 100%;
         height: 100%;
-        max-width: 1200px;
+        border: none;
       }
 
       /* --- Panel de Navegación --- */
@@ -385,10 +401,13 @@
         </nav>
       </aside>
 
-      <main id="content-area">
-        <div id="content-wrapper"></div>
-      </main>
-    </div>
+        <main id="content-area">
+          <div id="content-wrapper"></div>
+        </main>
+        <aside id="ai-panel">
+          <iframe src="../ai_dashboard.html"></iframe>
+        </aside>
+      </div>
 
     <!-- ########## TEMPLATES ########## -->
 

--- a/gastroenterologia/hemorragia-GI.html
+++ b/gastroenterologia/hemorragia-GI.html
@@ -10,6 +10,8 @@
     />
 
     <link href="../assets/tailwind.css" rel="stylesheet" />
+    <link rel="stylesheet" href="../assets/gastro-layout.css" />
+    <script src="../assets/gastro-layout.js" defer></script>
   </head>
   <body class="font-sans bg-gray-100">
     <header

--- a/gastroenterologia/manejo-multidisciplinario.html
+++ b/gastroenterologia/manejo-multidisciplinario.html
@@ -52,16 +52,32 @@
         main#content-area {
             flex-grow: 1;
             padding: 30px;
-            overflow-y: auto;
+            overflow: auto;
             display: flex;
             justify-content: center;
-            align-items: flex-start;
+            align-items: center;
         }
-        
+
         #content-wrapper {
+            width: 816px;
+            height: 1056px;
+            max-width: 100%;
+            max-height: 100%;
+            background-color: var(--card-bg);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+            overflow: auto;
+        }
+
+        aside#ai-panel {
+            width: 360px;
+            background-color: var(--card-bg);
+            box-shadow: -2px 0 10px rgba(0,0,0,0.05);
+            flex-shrink: 0;
+        }
+        #ai-panel iframe {
             width: 100%;
             height: 100%;
-            max-width: 1200px;
+            border: none;
         }
 
         /* --- Panel de Navegación --- */
@@ -200,6 +216,9 @@
         <main id="content-area">
              <div id="content-wrapper"></div>
         </main>
+        <aside id="ai-panel">
+            <iframe src="../ai_dashboard.html"></iframe>
+        </aside>
     </div>
 
     <!-- ########## TEMPLATES ########## -->

--- a/gastroenterologia/pancreatitis_aguda/index.html
+++ b/gastroenterologia/pancreatitis_aguda/index.html
@@ -10,6 +10,8 @@
     />
 
     <link href="../../assets/tailwind.css" rel="stylesheet" />
+    <link rel="stylesheet" href="../../assets/gastro-layout.css" />
+    <script src="../../assets/gastro-layout.js" defer></script>
   </head>
   <body class="font-sans">
     <div class="main-container">


### PR DESCRIPTION
## Summary
- centralize gastroenterology layout with new CSS/JS for left navigation, letter‑size canvas, and AI dashboard panel
- integrate layout assets into gastroenterology module pages and add AI dashboard panel to existing interactive modules

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4fe2395d0832ea4ffa59674c9248f