### PR TITLE
Update neuromusculares header branding

### DIFF
--- a/neurologia/neuromusculares.html
+++ b/neurologia/neuromusculares.html
@@ -76,13 +76,12 @@
     <!-- Header -->
     <header class="bg-white shadow-sm sticky top-0 z-50">
       <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
-        <a href="#" class="flex items-center space-x-2">
+        <a href="#" class="flex items-center">
           <!-- Placeholder for a logo -->
           <i class="fas fa-brain text-3xl text-indigo-600"></i>
-          <span class="text-2xl font-bold gradient-text">CanvasMed-AI</span>
         </a>
         <div>
-          <a href="#" class="text-indigo-600 font-semibold hover:underline">Hub</a>
+          <a href="../index.html" class="text-indigo-600 font-semibold hover:underline">PowerSemiotics</a>
         </div>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- Remove CanvasMed-AI label from neuromusculares page header
- Add PowerSemiotics link to home page in the navigation bar

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a535a2f218832ea6568c7dd8206734