### PR TITLE
feat: replace CanvasMed-AI with PowerSemiotics

### DIFF
--- a/neurologia/neuromusculares.html
+++ b/neurologia/neuromusculares.html
@@ -187,7 +187,7 @@
                   <head>
                       <meta charset=&quot;UTF-8&quot;>
                       <meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1.0&quot;>
-                      <title>CanvasMed-AI: Enfermedades Neuromusculares</title>
+                      <title>PowerSemiotics: Enfermedades Neuromusculares</title>
                       <link rel=&quot;preconnect&quot; href=&quot;https://fonts.googleapis.com&quot;>
                       <link rel=&quot;preconnect&quot; href=&quot;https://fonts.gstatic.com&quot; crossorigin>
                       <link href=&quot;https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap&quot; rel=&quot;stylesheet&quot;>
@@ -216,7 +216,7 @@
                           let currentSlide = 0;
                           const STYLES = { BACKGROUND: '#0f172a', TEXT: '#f8fafc', ACCENT: '#38bdf8', TABLE_HEADER_BG: '#1e293b', TABLE_BORDER: '#334155', FONT_FAMILY: 'Inter, sans-serif' };
                           const slides = [
-                              { type: 'title', title: 'Enfermedades de la Unión Neuromuscular y Músculo', subtitle: 'Un Análisis Clínico por CanvasMed-AI' },
+                              { type: 'title', title: 'Enfermedades de la Unión Neuromuscular y Músculo', subtitle: 'Un Análisis Clínico por PowerSemiotics' },
                               { type: 'content', title: 'Introducción: Enfermedades Neuromusculares (ENM)', points: ['Grupo heterogéneo de patologías que afectan la unidad motora.', 'Abarcan desde la motoneurona hasta el músculo.', 'Son condiciones crónicas, progresivas y a menudo incapacitantes.', 'Clasificación principal: Trastornos de la unión, Distrofias y Miopatías.'] },
                               { type: 'content', title: 'Fisiopatología de la Miastenia Gravis (MG)', points: ['Enfermedad autoinmune mediada por anticuerpos.', 'Ataque a proteínas de la membrana postsináptica, principalmente receptores de acetilcolina (AChR).', 'Resultado: Interrupción de la transmisión neuromuscular.', 'El timo juega un papel central, con hiperplasia o timomas frecuentes.'] },
                               { type: 'content', title: 'Clínica de la Miastenia Gravis', points: ['Característica principal: Debilidad muscular fluctuante y fatigable.', 'Forma Ocular: Ptosis (párpado caído) y diplopía (visión doble).', 'Forma Generalizada: Afecta músculos bulbares (habla, deglución), axiales y de extremidades.', 'Crisis Miasténica: Emergencia médica con compromiso respiratorio que requiere ventilación mecánica.'] },


### PR DESCRIPTION
Replaces all instances of 'CanvasMed-AI' with 'PowerSemiotics' in the `neurologia/neuromusculares.html` file, as requested by the user.