### PR TITLE
feat: Improve Parkinson's disease learning module page

### DIFF
--- a/trastornos-movimiento-1.html
+++ b/trastornos-movimiento-1.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Enfermedad de Parkinson: Trastornos del Movimiento I | Power Semiotics</title>
+    <meta name="description" content="Aprenda sobre la Enfermedad de Parkinson: desde su epidemiología en Ecuador hasta la fisiopatología. Módulo interactivo para estudiantes y profesionales.">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 800px;
+            margin: 20px auto;
+            padding: 0 20px;
+            background-color: #f9f9f9;
+        }
+        header, footer {
+            text-align: center;
+            margin: 20px 0;
+            color: #555;
+        }
+        a {
+            color: #007bff;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        h1, h2, h3 {
+            color: #2c3e50;
+            margin-top: 1.5em;
+        }
+        h1 {
+            text-align: center;
+            border-bottom: 2px solid #e0e0e0;
+            padding-bottom: 10px;
+        }
+        .learning-path-intro {
+            text-align: center;
+            font-style: italic;
+            color: #666;
+            margin-bottom: 2em;
+        }
+        .resource-list {
+            list-style: none;
+            padding: 0;
+        }
+        .resource-list li a {
+            display: block;
+            background-color: #ffffff;
+            border: 1px solid #ddd;
+            padding: 15px;
+            margin-bottom: 10px;
+            border-radius: 8px;
+            transition: box-shadow 0.3s ease, transform 0.3s ease;
+            font-weight: bold;
+        }
+        .resource-list li a:hover {
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+            transform: translateY(-2px);
+            text-decoration: none;
+        }
+        .resource-list li a .resource-title {
+            font-size: 1.1em;
+        }
+        .resource-list li a .resource-subtitle {
+            font-size: 0.9em;
+            font-weight: normal;
+            color: #555;
+            display: block;
+            margin-top: 5px;
+        }
+        strong {
+            color: #34495e;
+        }
+        ul {
+            padding-left: 20px;
+        }
+        ul li {
+            margin-bottom: 10px;
+        }
+    </style>
+</head>
+<body>
+
+    <header>
+        <a href="https://powersemiotics.com/neurologia.html" aria-label="Regresar a la página principal del Hub de Neurología">&larr; Volver al Hub de Neurología</a>
+    </header>
+
+    <main>
+        <h1>Módulo: Trastornos del Movimiento I</h1>
+        <p class="learning-path-intro">Siga los pasos en orden para una experiencia de aprendizaje completa.</p>
+
+        <section aria-labelledby="parkinson-guide-title">
+            <h2 id="parkinson-guide-title">Guía Esencial de la Enfermedad de Parkinson</h2>
+
+            <h3>Introducción y Epidemiología: La Realidad del Parkinson en Ecuador</h3>
+            <p>
+                La <strong>Enfermedad de Parkinson (EP)</strong> es el trastorno del movimiento neurodegenerativo más común después de la enfermedad de Alzheimer. Se caracteriza por la pérdida progresiva de <strong>neuronas dopaminérgicas</strong> en el cerebro, lo que lleva a los síntomas motores que definen esta condición. Aunque su causa exacta es desconocida, se cree que una compleja interacción de factores genéticos y ambientales contribuye al desarrollo de este trastorno del movimiento.
+            </p>
+
+            <h3>Fisiopatología: La Vía Nigroestriada y la Agregación de α-Sinucleína</h3>
+            <p>
+                La fisiopatología de la EP se centra en la <strong>vía nigroestriada</strong>. El proceso clave es la degeneración progresiva de las neuronas dopaminérgicas en la sustancia negra pars compacta (SNc). Esta pérdida de dopamina provoca un desequilibrio en los ganglios basales, afectando directamente el control del movimiento.
+            </p>
+            <p>Los elementos centrales de esta patología incluyen:</p>
+            <ul>
+                <li><strong>Inhibición del movimiento:</strong> La alteración de la vía directa e indirecta de los ganglios basales conduce a síntomas como la bradicinesia (lentitud de movimiento).</li>
+                <li><strong>Agregación de proteínas:</strong> El sello distintivo a nivel celular es la presencia de <strong>cuerpos de Lewy</strong>, que son agregados anormales de la proteína α-sinucleína dentro de las neuronas.</li>
+            </ul>
+            <p>Comprender estos mecanismos es fundamental para el diagnóstico y tratamiento del Parkinson.</p>
+        </section>
+
+        <section aria-labelledby="interactive-resources-title">
+            <h2 id="interactive-resources-title">Recursos de Aprendizaje Interactivo</h2>
+            <p>Ahora que ha revisado los fundamentos de la Enfermedad de Parkinson, es momento de aplicar y expandir su conocimiento. Utilice las siguientes herramientas interactivas para explorar el espectro clínico, los criterios diagnósticos y casos prácticos.</p>
+            <ol class="resource-list">
+                <li>
+                    <!-- TODO: Replace # with the actual URL for this resource -->
+                    <a href="#" aria-label="Acceder a la Guía Esencial de la Enfermedad de Parkinson">
+                        <span class="resource-title">Guía de Conocimiento:</span>
+                        <span class="resource-subtitle">Guía Esencial de la Enfermedad de Parkinson</span>
+                    </a>
+                </li>
+                <li>
+                    <!-- TODO: Replace # with the actual URL for this resource -->
+                    <a href="#" aria-label="Iniciar la presentación interactiva sobre el Espectro Clínico del Parkinson">
+                        <span class="resource-title">Presentación Interactiva:</span>
+                        <span class="resource-subtitle">El Espectro Clínico del Parkinson</span>
+                    </a>
+                </li>
+                <li>
+                    <!-- TODO: Replace # with the actual URL for this resource -->
+                    <a href="#" aria-label="Consultar la herramienta de Criterios Diagnósticos de la MDS para Parkinson">
+                        <span class="resource-title">Herramienta:</span>
+                        <span class="resource-subtitle">Criterios Diagnósticos de la MDS</span>
+                    </a>
+                </li>
+                <li>
+                    <!-- TODO: Replace # with the actual URL for this resource -->
+                    <a href="#" aria-label="Comenzar la actividad interactiva: El Caso del Temblor Unilateral">
+                        <span class="resource-title">Actividad Interactiva:</span>
+                        <span class="resource-subtitle">ABP - "El Caso del Temblor Unilateral"</span>
+                    </a>
+                </li>
+                <li>
+                    <!-- TODO: Replace # with the actual URL for this resource -->
+                    <a href="#" aria-label="Realizar la autoevaluación de fundamentos con el banco de preguntas">
+                        <span class="resource-title">Banco de Preguntas:</span>
+                        <span class="resource-subtitle">Autoevaluación de Fundamentos</span>
+                    </a>
+                </li>
+            </ol>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2024 Power Semiotics. Todos los derechos reservados.</p>
+    </footer>
+
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a new, improved version of the "Trastornos del Movimiento I" learning module page.

The new file, `trastornos-movimiento-1.html`, incorporates several enhancements over the original page:

- **SEO & Metadata:** Added an optimized <title> and <meta name="description"> for better search engine visibility.
- **Structure & Readability:** Implemented a hierarchical heading structure (H1, H2s, H3s) and broke down dense paragraphs into more scannable formats, including bulleted lists.
- **Content:** Refined the text to improve keyword integration for terms like "Enfermedad de Parkinson" and "trastorno del movimiento". Added transitional text to guide the user's learning path.
- **Accessibility:** Enhanced all links with descriptive `aria-label` attributes to improve navigation for users with screen readers.
- **Styling:** Included modern, clean CSS for better visual presentation.

This commit also addresses feedback from the code review by:
- Adding TODO comments to placeholder links to indicate they need to be replaced with actual URLs.
- Updating the copyright year to 2024.