### PR TITLE
Remove redundant navigation elements on neurology pages

### DIFF
--- a/assets/ask-ai.js
+++ b/assets/ask-ai.js
@@ -6,22 +6,8 @@ document.addEventListener('DOMContentLoaded', () => {
     window.location.pathname.startsWith('/neurologia/');
 
   if (isNeurologySubpage) {
-    const leftWidth = 224; // Tailwind w-56
     const rightWidth = 384; // Tailwind w-96
-
-    document.body.style.marginLeft = `${leftWidth}px`;
     document.body.style.marginRight = `${rightWidth}px`;
-
-    const leftPanel = document.createElement('div');
-    leftPanel.className =
-      'hidden md:flex flex-col fixed top-0 left-0 h-full w-56 bg-gray-50 border-r p-4 space-y-4';
-    leftPanel.innerHTML = `
-      <nav class="space-y-2">
-        <a href="/index.html" class="block text-indigo-600 font-semibold hover:underline">Inicio</a>
-        <a href="/neurologia.html" class="block text-indigo-600 font-semibold hover:underline">Neurología</a>
-      </nav>
-    `;
-    document.body.appendChild(leftPanel);
 
     const rightPanel = document.createElement('div');
     rightPanel.className =

--- a/neurologia/neuropatias.html
+++ b/neurologia/neuropatias.html
@@ -111,33 +111,6 @@
                   <b class="text-blue-600">Autoevaluación Gamificada</b>.
                 </p>
 
-                <!-- Enlaces a los AI Dashboards -->
-                <div class="mt-8 bg-white p-4 rounded-lg shadow-md">
-                  <h4 class="text-lg font-semibold text-blue-600 mb-2">
-                    ¿Necesitas ayuda de IA con este tema?
-                  </h4>
-                  <ul class="list-disc list-inside space-y-1">
-                    <li>
-                      <a
-                        href="../ai_dashboard.html"
-                        class="text-blue-500 hover:underline"
-                        >AI Dashboard (API)</a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="../ai_dashboard_local.html"
-                        class="text-blue-500 hover:underline"
-                        >AI Dashboard (Local)</a
-                      >
-                    </li>
-                  </ul>
-                  <p class="text-sm text-gray-500 mt-2">
-                    Usa estos paneles para resumir, traducir, formular preguntas
-                    o generar ejemplos del contenido de este módulo.
-                  </p>
-                </div>
-                <!-- Fin de enlaces a los AI Dashboards -->
               </div>
             </section>
 


### PR DESCRIPTION
## Summary
- Stop ask-ai.js from injecting the PowerSemiotics left navigation panel on neurology subpages
- Remove redundant AI Dashboard links from the neuropatias module to reduce clutter

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a63aa54054832eb6af5fbab1891381